### PR TITLE
Use browserify to make the browser bundle at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/expected.c
 /cephes.wasm
 /index.js
 article/bundle.js
+/cephes-browser-bundled.js
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test/expected.c
 /index.js
 article/bundle.js
 /cephes-browser-bundled.js
+/cephes-browser-bundled.js.map
 
 # Logs
 logs

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ index.js: cephes.wasm $(CPROTOFILES) $(GENERATEFILES)
 	cproto $(CEPHESDIR)/*.c | grep -v ignore_ | node $(BUILDDIR)/generate-interface.js > index.js
 
 cephes-browser-bundled.js: index.js cephes-browser.js
-	./node_modules/.bin/browserify --standalone cephes --transform brfs -o $@ -e index.js
+	./node_modules/.bin/browserify --debug --standalone cephes --transform brfs -e index.js | exorcist cephes-browser-bundled.js.map > $@
 
 README.md: $(CEPHESDIR)/cephes.txt $(CPROTOFILES) $(GENERATEFILES)
 	cat $(BUILDDIR)/readme-header.md > README.md

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LFLAGS:=-O3 -g3
 
 .PHONY: download build test
 
-build: index.js README.md
+build: index.js cephes-browser-bundled.js README.md
 
 clean:
 	rm -f $(JS_OBJS)
@@ -183,6 +183,9 @@ cephes.standalone.wasm: $(JS_OBJS)
 
 index.js: cephes.wasm $(CPROTOFILES) $(GENERATEFILES)
 	cproto $(CEPHESDIR)/*.c | grep -v ignore_ | node $(BUILDDIR)/generate-interface.js > index.js
+
+cephes-browser-bundled.js: index.js cephes-browser.js
+	./node_modules/.bin/browserify --standalone cephes --transform brfs -o $@ -e index.js
 
 README.md: $(CEPHESDIR)/cephes.txt $(CPROTOFILES) $(GENERATEFILES)
 	cat $(BUILDDIR)/readme-header.md > README.md

--- a/package.json
+++ b/package.json
@@ -3,12 +3,9 @@
   "description": "Implementation of special functions and distributions mathematical functions from the cephes library.",
   "repository": "nearform/node-cephes",
   "version": "1.1.2",
-  "main": "index.js",
+  "main": "./",
   "scripts": {
     "test": "tap test/*.test.js"
-  },
-  "dependencies": {
-    "brfs": "^2.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",
@@ -17,24 +14,23 @@
     "@babel/runtime": "^7.0.0",
     "almost-equal": "^1.1.0",
     "babelify": "^10.0.0",
+    "brfs": "^2.0.1",
+    "browserify": "^16.2.3",
     "d3-array": "^1.2.4",
     "d3-axis": "^1.0.12",
     "d3-scale": "^2.1.2",
     "d3-scale-chromatic": "^1.3.3",
     "d3-selection": "^1.3.2",
     "d3-shape": "^1.2.2",
+    "exorcist": "^1.0.1",
     "pumpify": "^1.5.1",
     "split2": "^3.0.0",
     "tap": "^12.0.1",
     "xorshift": "^1.1.1"
   },
   "browser": {
+    "./": "cephes-browser-bundled.js",
     "./cephes.js": "./cephes-browser.js"
-  },
-  "browserify": {
-    "transform": [
-      "brfs"
-    ]
   },
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Accomplishes the same as #4 with browserify instead of rollup.

It was pretty fiddly to set up the `main` and `browser` fields in `package.json` so that `./cephes.js` is remapped to `./cephes-browser.js` when creating the browser bundle from the project itself, while making sure that `./index.js` gets loaded when requiring the package in node and that `cephes-browser-bundled.js` gets used when browserifying an application that uses cephes :sweat_smile:

For that reason I still think rollup is better.